### PR TITLE
Update requirements.txt(for tag:2.20.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@
 pbr>=0.6,!=0.7,<1.0
 argparse
 iso8601>=0.1.9
-oslo.utils>=1.0.0                       # Apache-2.0
+oslo.i18n<1.6.0,>=1.5.0                 # Apache-2.0
+oslo.serialization<1.5.0,>=1.4.0        # Apache-2.0
+oslo.utils<1.5.0,>=1.4.0                # Apache-2.0
 PrettyTable>=0.7,<0.8
 requests>=1.2.1,!=2.4.0
 simplejson>=2.2.0


### PR DESCRIPTION
When install the nove clinet,there are some errors caused by olso,
so upgrade the olso's version to fix these errors.